### PR TITLE
Request shutdown.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 gw
+shutdown
 *.o
 *~

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,11 @@
-all: gw
+all: gw shutdown
 
 CFLAGS=-Wall -W -g
 
 gw: gw.o chaos.o
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
+
+shutdown: shutdown.o chaos.o
 	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 clean:
@@ -10,3 +13,4 @@ clean:
 
 gw.o:: chaos.h
 chaos.o:: chaos.h
+shutdown.o:: chaos.h

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ Chaosnet servers may not be hardened against malicious attacks.
 
 There is a unit file chaosnet-gateway.service for systemd; make sure
 to update `WorkingDirectory`.  Edit the gateway.sh script to your liking.
+
+## `shutdown` &mdash; Request to shut down Chaosnet host.
+
+Usage: `shutdown` *host* [*data*]
+
+Send a request to *host* to shut itself down.  Optional *data* can be
+sent which the host may interpret as information about how to shut down.

--- a/chaos.c
+++ b/chaos.c
@@ -48,12 +48,23 @@ int chaos_stream(void)
   return connect_to_named_socket(SOCK_STREAM, "chaos_stream");
 }
 
-int chaos_rfc(int fd, const char *host, const char *contact)
+int chaos_stream_rfc_data(int fd, const char *host, const char *contact,
+                          void *data, size_t len)
 {
   char buffer[500];
   ssize_t n;
 
-  if (dprintf(fd, "RFC %s %s\r\n", host, contact) < 0)
+  if (dprintf(fd, "RFC %s %s", host, contact) < 0)
+    return -1;
+
+  if (len > 0) {
+    char space = ' ';
+    if (write(fd, &space, 1) != 1)
+      return -1;
+    if (write(fd, data, len) != (ssize_t)len)
+      return -1;
+  }
+  if (dprintf(fd, "\r\n") < 0)
     return -1;
 
   n = read(fd, buffer, sizeof buffer);
@@ -70,4 +81,9 @@ int chaos_rfc(int fd, const char *host, const char *contact)
   }
 
   return 0;
+}
+
+int chaos_stream_rfc(int fd, const char *host, const char *contact)
+{
+  return chaos_stream_rfc_data(fd, host, contact, NULL, 0);
 }

--- a/chaos.h
+++ b/chaos.h
@@ -1,9 +1,12 @@
 #ifndef CHAOS_H
 #define CHAOS_H
 
+#include <sys/types.h>
+
 #define MAX_PACKET 492
 
 int chaos_stream(void);
-int chaos_rfc(int fd, const char *host, const char *contact);
+int chaos_stream_rfc(int fd, const char *host, const char *contact);
+int chaos_stream_rfc_data(int, const char *, const char *, void *, size_t);
 
 #endif /* CHAOS_H */

--- a/gw.c
+++ b/gw.c
@@ -103,7 +103,7 @@ static void incoming(void)
   if (c < 0)
     fatal("creating Chaosnet stream", errno);
 
-  if (chaos_rfc(c, host, contact) < 0)
+  if (chaos_stream_rfc(c, host, contact) < 0)
     fatal("error during request for connection", errno);
   fprintf(stderr, "Opened connection to %s contact %s\n", host, contact);
   forward(s, c);

--- a/shutdown.c
+++ b/shutdown.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "chaos.h"
+
+static const char *contact = "SHUTDOWN";
+
+static void usage(char *name)
+{
+  fprintf(stderr, "Usage: %s <host> [data]\n", name);
+  exit(1);
+}
+
+int main(int argc, char **argv)
+{
+  int fd;
+
+  if (argc < 2 || argc > 3)
+    usage(argv[0]);
+
+  fd = chaos_stream();
+  if (argc == 2)
+    chaos_stream_rfc(fd, argv[1], contact);
+  else
+    chaos_stream_rfc_data(fd, argv[1], contact, argv[2], strlen(argv[2]));
+
+  return 0;
+}


### PR DESCRIPTION
Simple command to send a shutdown request to a Chaosnet host.  The protocol is to send an RFC to the SHUTDOWN contact, with optional data after.  The server shuts down the host according to its interpretation of the data, and sends an ANS back.  The server is expected to take precautions with regards to which node is allowed to shut it down.