### PR TITLE
RTAPE protocol format correction and some new features for collaboration

### DIFF
--- a/rtape.c
+++ b/rtape.c
@@ -419,9 +419,9 @@ static void send_status(int id, const char *message)
   buf[0] = VERSION;
   buf[1] = id & 0xFF;
   buf[2] = (id >> 8) & 0xFF;
-  buf[33] = flags & 0xFF;
-  buf[34] = (flags >> 8) & 0xFF;
-  memset(&buf[1+2+3+3+3+1+2+2], 0, 16);
+  buf[34] = flags & 0xFF;
+  buf[35] = (flags >> 8) & 0xFF;
+  memset(&buf[1+2+3+3+3+1+2+2], 0, 17);
   if (flags & FLG_MNT) {
     int len = strlen(mounted_drive);
     memcpy(&buf[1+2+3+3+3+1+2+2+1], mounted_drive, len);
@@ -439,10 +439,9 @@ static void send_status(int id, const char *message)
     memset(last_message, 0, sizeof(last_message));
   if (mp) {
     fprintf(debug, "Peer %s: Send status: %s\n", peer, mp);
-    buf[33] |= FLG_STRG;
+    buf[34] |= FLG_STRG;
     // Again, defined constants would be nice
     n = MIN(strlen(mp), sizeof buf - 36);
-    buf[35]=n;
     memcpy(buf+36, mp, n);
   }
   send_command(CMD_STS, buf, 36 + n);

--- a/rtape.c
+++ b/rtape.c
@@ -441,10 +441,11 @@ static void send_status(int id, const char *message)
     fprintf(debug, "Peer %s: Send status: %s\n", peer, mp);
     buf[33] |= FLG_STRG;
     // Again, defined constants would be nice
-    n = MIN(strlen(mp), sizeof buf - 35);
-    memcpy(buf+35, mp, n);
+    n = MIN(strlen(mp), sizeof buf - 36);
+    buf[35]=n;
+    memcpy(buf+36, mp, n);
   }
-  send_command(CMD_STS, buf, 35 + n);
+  send_command(CMD_STS, buf, 36 + n);
 }
 
 static void cmd_probe(const unsigned char *data, int len)


### PR DESCRIPTION
- Fix for interoperability with ITS DUMP (problem with status field fixed)

- Added more freedom for mapping tapes to file names on the tape server  remote system: The default behaviour continues to name tape files as the name of the drive to mount, passed by the remote client.
The new options -R and -W allow to specify a printf-style format string (separately for READ-only  and WRITE or BOTh (R/W)
mounts where the client's chaosnet peer address and the drive name can be used as filename components. Examples
are given in the usage help output.

The main use case could be a remote server that will prevent tapes from different client hosts to accidentally overwrite
each other, but allowing remote hosts to exchange tapes in read-only mounts. 